### PR TITLE
fix: remove unsupported web_search tool + raise VPC harness-ready timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of cascade-deleting it.
 - Config-drift hash extended to cover model union, memory, skills, environment,
   and container so changes to any of them trigger an UpdateHarness.
+- Harness-ready polling timeout raised from 180s to 600s. VPC harness creation
+  (network-interface provisioning + container pull through the NAT) can take
+  several minutes; the shorter timeout reported a misleading "did not reach
+  READY" error on harnesses that were still creating.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Inline functions** — new tool type; the node surfaces `stopReason: tool_use`
   with parsed tool inputs and a Tool Results field to send results back over the
   same session.
-- **AgentCore Web Search** — managed `agentcore_web_search` tool type, no setup.
 - **OAuth Bearer invoke** — Authentication selector with an operation-level
   Bearer Token field. Uses a raw HTTPS request and an event-stream decoder
   (`@smithy/core/event-streams`) because the AWS SDK cannot Bearer-auth

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ n8n’s native AI Agent node is great for simple agents, but hits walls fast: no
 - **Bring your own harness** — Paste a harness ARN (deployed via CLI / CloudFormation / console / Terraform) to invoke it directly, with any config field acting as a per-invocation override
 - **Multi-provider models** (v0.2) — Amazon Bedrock (native), OpenAI, Google Gemini, and LiteLLM, switchable per invocation
 - **Managed memory** (v0.2) — auto-provisioned AgentCore Memory with configurable strategies, or bring your own Memory ARN, or disable it
-- **Inline tool configuration** — AgentCore Browser, Code Interpreter, Web Search, Gateway (with optional OAuth outbound auth), remote MCP servers, and inline functions
+- **Inline tool configuration** — AgentCore Browser, Code Interpreter, Gateway (with optional OAuth outbound auth), remote MCP servers, and inline functions
 - **Skills** (v0.2) — AWS curated catalog, Git, S3, and filesystem-path sources
 - **VPC, custom containers, and filesystem mounts** (v0.2) — run in your VPC, bring a linux/arm64 ECR image, mount session storage / EFS / S3 Files
 - **OAuth Bearer invoke** (v0.2) — invoke inbound-OAuth harnesses with a JWT from an upstream node
@@ -202,9 +202,12 @@ So: short-term continuity needs a stable **Session ID**; long-term recall needs
 
 ### Tools & skills
 
-Tools now include **Web Search** (managed, no setup), **Gateway** with optional
-OAuth outbound auth, and **Inline Functions**. **Skills** load domain knowledge
-on demand from the AWS catalog (glob patterns), Git, S3, or a filesystem path.
+Tools now include **Gateway** with optional OAuth outbound auth and **Inline
+Functions**, alongside Browser, Code Interpreter, and remote MCP. **Skills** load
+domain knowledge on demand from the AWS catalog (glob patterns), Git, S3, or a
+filesystem path. (Need web search? Point a Remote MCP tool at a search MCP
+server — a managed `agentcore_web_search` type is documented by AgentCore but not
+yet accepted by the harness API.)
 
 #### Inline-function round-trip
 
@@ -394,7 +397,7 @@ The package name `@aws/n8n-nodes-agentcore` matches n8n’s required
 |Version           |Capability                                                                                       |
 |------------------|-------------------------------------------------------------------------------------------------|
 |**v0.1**          |Run Agent, Invoke Existing, MCP / Browser / Code Interpreter / Gateway tools, streaming, sessions|
-|**v0.2** (current)|Multi-provider models, managed memory, VPC, custom containers, filesystem mounts, skills, inline functions, web search, OAuth Bearer invoke, versions & endpoints|
+|**v0.2** (current)|Multi-provider models, managed memory, VPC, custom containers, filesystem mounts, skills, inline functions, OAuth Bearer invoke, versions & endpoints|
 |**later**         |ExecuteCommand (shell) with Bearer, custom Browser/Code Interpreter resources, CloudFormation quick-create, Export to Code, Step Functions|
 
 ## Limitations (v0.2)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ to run harnesses in your VPC. Provisioning Options add a **Container Image URI**
 (linux/arm64 ECR) and **Filesystem Mounts** (session storage with no VPC; EFS and
 S3 Files access points require VPC).
 
+> **VPC requirements:** the subnets you provide must route `0.0.0.0/0` to a **NAT
+> gateway** — the harness pulls its container from `public.ecr.aws` at session
+> start, and ECR Public has no VPC endpoint, so a NAT-less/isolated subnet causes
+> image-pull timeouts. **First creation of a VPC harness is slow** (network
+> interface provisioning + container pull through the NAT can take several
+> minutes); the node waits up to 10 minutes. Subsequent runs reuse the harness
+> and return in seconds.
+
 ### OAuth Bearer invoke
 
 For a harness with an inbound OAuth (JWT) authorizer, set **Authentication =
@@ -422,7 +430,7 @@ The package name `@aws/n8n-nodes-agentcore` matches n8n’s required
 | **The agent doesn't remember previous turns** | The **Session ID** was left blank, so each run is a new conversation (output shows `sessionSource: "generated"`). Set a stable Session ID and reuse it across runs. See [Memory & sessions](#memory--sessions). |
 | **`AccessDenied` / `not authorized to perform` on the first run** | Either the **Bedrock model isn't enabled** (Bedrock console → Model access), or the **execution role is missing a scoped action** for the feature you used (e.g. `bedrock-mantle:CreateInference` for Mantle models, token-vault read for OpenAI/Gemini keys, `InvokeGateway` for gateways). See [IAM setup](#iam-setup). |
 | **First run hangs for ~30 seconds** | Expected — the node is creating the harness on first use. Subsequent runs reuse it and return in a few seconds. |
-| **VPC harness fails / sessions time out on start** | The harness pulls its container from `public.ecr.aws`, which has no VPC endpoint. The subnet you configured must route `0.0.0.0/0` to a **NAT gateway** (→ internet gateway). Fix the route table or use a NAT-routed subnet. |
+| **"Harness … did not reach READY within …" on a VPC harness** | VPC harness creation is slow (ENI provisioning + container pull through the NAT). The node now waits up to 10 minutes; if you still see this, the harness is often **still creating** — re-run the node shortly and it will find the now-READY harness and invoke it. A *persistent* failure (or `CREATE_FAILED`) points at egress: the subnet must route `0.0.0.0/0` to a **NAT gateway** (ECR Public has no VPC endpoint). Fix the route table or use a NAT-routed subnet. |
 | **OpenAI / Gemini model errors about a missing key** | Direct OpenAI/Gemini require an **API Key ARN** (a token-vault credential provider) in Model Options. To use OpenAI-style models without a key, pick the **Bedrock** provider with API Format `Responses`/`Chat Completions` and a Mantle model id. |
 | **Two "Amazon Bedrock AgentCore" nodes in the palette** | A leftover/older install. Remove the stale package from `~/.n8n/nodes` (or `~/.n8n/custom`), then fully restart n8n and open a fresh browser tab. |
 | **OAuth invoke returns 401 / Unauthorized** | The harness needs an **inbound JWT authorizer** configured, and the Bearer Token must be a valid, unexpired JWT from that IdP whose `aud`/`client_id`/scopes satisfy the authorizer. See [OAuth Bearer invoke](#oauth-bearer-invoke). |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -100,7 +100,7 @@ See [memory & sessions](../README.md#memory--sessions) in the README.)
 
 ## Where to go next
 
-- **Tools** — add a Web Search or Code Interpreter tool to the node.
+- **Tools** — add a Code Interpreter, Browser, or remote MCP tool to the node.
 - **Other models** — switch Model Provider to OpenAI / Gemini / LiteLLM (needs an
   API key ARN), or use Bedrock Mantle without a key.
 - **Examples** — import any workflow from [`examples/`](../examples).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -22,7 +22,7 @@ The node auto-provisions a harness on first execution, reuses it on subsequent r
 
 - One n8n node (`AgentCoreHarness`) with a single operation; the Harness ARN field selects between auto-provision and bring-your-own-ARN behavior
 - One credential type (`AgentCoreApi`) reusing n8n’s standard AWS credential pattern, extended with optional VPC network config
-- Inline tool configuration for AgentCore-native tools: Browser, Code Interpreter, Gateway (with optional OAuth outbound auth), remote MCP, **Web Search**, and **inline functions**
+- Inline tool configuration for AgentCore-native tools: Browser, Code Interpreter, Gateway (with optional OAuth outbound auth), remote MCP, and **inline functions**
 - **Multi-provider models** — Amazon Bedrock (native + Mantle), OpenAI, Google Gemini, LiteLLM — switchable per invocation
 - **Managed memory auto-provisioning** (strategies + event expiry), with BYO-Memory-ARN and Disabled modes
 - **Skills** from the AWS curated catalog, Git, S3, and filesystem paths
@@ -119,7 +119,7 @@ A single operation. The **Harness ARN** field is the mode discriminator: blank �
 |Model Options       |collection|no            |always    |API Key ARN, API Base URL, API Format, temperature, topP/K, model max tokens, additionalParams (JSON).         |
 |System Prompt       |string    |no            |always    |Agent instructions. Run mode: defaults if blank. Invoke mode: override if set.                                 |
 |Prompt              |string    |no            |always    |User message (n8n expressions supported). Optional only when sending Tool Results back.                        |
-|Tools               |collection|no            |always    |Browser, Code Interpreter, Gateway (+OAuth), remote MCP, Web Search, inline functions. Invoke mode: override.  |
+|Tools               |collection|no            |always    |Browser, Code Interpreter, Gateway (+OAuth), remote MCP, inline functions. Invoke mode: override.             |
 |Skills              |collection|no            |always    |AWS catalog (globs) / Git / S3 / filesystem path. Run mode: baked in. Invoke mode: appended (invoke wins).     |
 |Session ID          |string    |no            |always    |For multi-turn continuity. Auto-generated (random UUID) when blank; stable value continues a conversation.     |
 |Authentication      |options   |no            |always    |AWS SigV4 (default) or OAuth Bearer Token. OAuth uses the raw-HTTPS invoke path.                                |
@@ -298,7 +298,7 @@ AWS setup runbook are maintained by the team outside the published package.
 3. Re-run same workflow — fast reuse, same harness ID
 4. Modify system prompt/model/tools — `UpdateHarness`, new version, response reflects update
 5. Multi-turn with a stable session ID — second turn recalls the first (`sessionSource: provided`, higher inputTokens)
-6. Tools: MCP, Code Interpreter, Browser, Web Search — agent uses the tool
+6. Tools: MCP, Code Interpreter, Browser — agent uses the tool
 7. Multi-provider: OpenAI/Gemini/LiteLLM, and a mid-session provider switch
 8. Inline function — `stopReason: tool_use` then Tool Results round-trip
 9. Skills (AWS catalog / Git / S3), VPC harness, custom container, filesystem mount
@@ -357,4 +357,4 @@ default model is Claude Sonnet 4.6.
 |Version|Date             |Notes                                                                                                               |
 |-------|-----------------|--------------------------------------------------------------------------------------------------------------------|
 |0.1.0  |TBD (pre-release)|Initial release: single operation (auto-provision or bring-your-own-ARN), MCP/Browser/Code Interpreter/Gateway tools|
-|0.2.0  |TBD (pre-release)|Multi-provider models, managed memory, VPC, custom containers, filesystem mounts, skills, inline functions, web search, OAuth Bearer invoke, versions & endpoints. SDK bumped to ^3.1071.0.|
+|0.2.0  |TBD (pre-release)|Multi-provider models, managed memory, VPC, custom containers, filesystem mounts, skills, inline functions, OAuth Bearer invoke, versions & endpoints. SDK bumped to ^3.1071.0.|

--- a/nodes/AgentCoreHarness/descriptions/Common.ts
+++ b/nodes/AgentCoreHarness/descriptions/Common.ts
@@ -6,11 +6,11 @@ import type { INodeProperties } from 'n8n-workflow';
 
 /**
  * Tool collection field. Used by both auto-provisioned and BYO-ARN modes.
- * v0.2 supports: AgentCore Browser, Code Interpreter, Web Search, Gateway
- * (with optional OAuth outbound auth), Remote MCP, and inline functions.
+ * v0.2 supports: AgentCore Browser, Code Interpreter, Gateway (with optional
+ * OAuth outbound auth), Remote MCP, and inline functions.
  *
  * Per-tool fields are shown/hidden by the selected Type so the form stays
- * legible across six tool types. Values are kept alphabetized by displayName to
+ * legible across the tool types. Values are kept alphabetized by displayName to
  * satisfy eslint-plugin-n8n-nodes-base.
  */
 export const toolsField: INodeProperties = {
@@ -118,7 +118,6 @@ export const toolsField: INodeProperties = {
 						{ name: 'AgentCore Browser', value: 'agentcore_browser' },
 						{ name: 'AgentCore Code Interpreter', value: 'agentcore_code_interpreter' },
 						{ name: 'AgentCore Gateway', value: 'agentcore_gateway' },
-						{ name: 'AgentCore Web Search', value: 'agentcore_web_search' },
 						{ name: 'Inline Function', value: 'inline_function' },
 						{ name: 'Remote MCP Server', value: 'remote_mcp' },
 					],

--- a/nodes/AgentCoreHarness/helpers/client.ts
+++ b/nodes/AgentCoreHarness/helpers/client.ts
@@ -57,12 +57,17 @@ function splitList(raw: string | undefined): string[] {
 
 /**
  * Polls GetHarness until READY or a terminal failure state.
- * Default timeout 180 seconds matches typical harness creation time.
+ * Default timeout 600 seconds (10 min): public harnesses are ready in ~30s, but
+ * VPC harnesses take materially longer — AWS provisions network interfaces in
+ * your subnets and pulls the container from public.ecr.aws through your NAT,
+ * which can exceed several minutes. A short timeout surfaced a misleading
+ * "did not reach READY" error on VPC harnesses that were in fact still creating
+ * (and did become READY shortly after).
  */
 export async function waitForHarnessReady(
 	controlClient: any,
 	harnessId: string,
-	timeoutMs: number = 180_000,
+	timeoutMs: number = 600_000,
 ): Promise<{ status: string; failureReason?: string }> {
 	const { GetHarnessCommand } = await import('@aws-sdk/client-bedrock-agentcore-control');
 	const startedAt = Date.now();

--- a/nodes/AgentCoreHarness/helpers/tools.ts
+++ b/nodes/AgentCoreHarness/helpers/tools.ts
@@ -21,12 +21,12 @@ export interface ToolConfig {
  *   - agentcore_gateway        (+ optional OAuth outbound auth)
  *   - remote_mcp
  *   - inline_function          (client-side execution; round-trips via toolResult)
- *   - agentcore_web_search     (managed; no config)
  *
- * NOTE (TODO(v0.2-question-5)): `agentcore_web_search` is documented in the GA
- * dev guide but is not yet in the SDK's HarnessToolType enum. The SDK schema
- * serializes `HarnessTool.type` as a plain string (verified in schemas_0.js),
- * so the raw value is sent verbatim and accepted by the service.
+ * Note: `agentcore_web_search` is described in the developer guide but is not yet
+ * accepted by the Create/Update/Invoke Harness APIs (the service enum rejects it
+ * with a ValidationException), so it is intentionally not offered here. Web
+ * search can still be added today via a Remote MCP search server. Re-add the
+ * managed type once the harness API enum includes it.
  */
 export function buildToolsArray(toolsUi: IDataObject | undefined): ToolConfig[] {
 	if (!toolsUi || !toolsUi.tool) {
@@ -51,14 +51,6 @@ export function buildToolsArray(toolsUi: IDataObject | undefined): ToolConfig[] 
 				tools.push({
 					type: 'agentcore_code_interpreter',
 					name: (uiTool.name as string) || 'code_interpreter',
-				});
-				break;
-
-			case 'agentcore_web_search':
-				// Managed web search via Gateway, no setup required. No config.
-				tools.push({
-					type: 'agentcore_web_search',
-					name: (uiTool.name as string) || 'web_search',
 				});
 				break;
 


### PR DESCRIPTION
## Description

Two fixes found during end-to-end testing of the v0.2 GA features:

**1. Remove `agentcore_web_search` tool type.** The AgentCore developer guide
documents it, but the GA Create/Update/Invoke Harness API rejects it — the
service tool-type enum only accepts
`[remote_mcp, agentcore_code_interpreter, agentcore_gateway, agentcore_browser, inline_function]`
and returns a `ValidationException` for `agentcore_web_search`. A harness create
failed with that enum error in testing. Removed the option from the Tools
dropdown and the build path so users can't pick a value that hard-fails; docs
note the Remote MCP alternative and that the managed type can return once the API
enum includes it.

**2. Raise harness-ready timeout 180s → 600s for VPC creation.** VPC harness
creation provisions network interfaces in the subnets and pulls the container
from `public.ecr.aws` through the NAT, which can take several minutes — past the
old 180s poll timeout. That surfaced a misleading "Harness … did not reach READY
within 180000ms" error on a harness that was in fact still creating and became
READY shortly after. Verified against a real VPC harness (status went READY with
no failure reason). Added VPC requirements + slow-first-run guidance to the
README and clarified the troubleshooting row.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Documentation update

## Testing

- [x] `npm run build` / `typecheck` / `lint` / `format:check` pass
- [x] Tool dropdown lists the 5 service-supported types only (verified)
- [x] VPC harness reaches READY within the new timeout (verified end-to-end in a
  real account: subnets NAT-routed, harness status READY, `networkMode: VPC`)
- [x] Valid tool types still build correctly

## Security / IAM

- [x] No `exec`/`spawn`/`eval`/fs-write changes; no dependency changes

## Checklist

- [x] PR title follows Conventional Commits (`fix:`)
- [x] CHANGELOG / README / SPEC / QUICKSTART updated as needed

---

By submitting this pull request, I confirm my contribution is made under the terms of the project's Apache-2.0 license.
