### PR TITLE
chore: prep v0.2.0 release (set base to 0.1.1, changelog date, fix n8n discovery docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - YYYY-MM-DD
+## [0.2.0] - 2026-06-24
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -389,11 +389,18 @@ The package name `@aws/n8n-nodes-agentcore` matches n8n’s required
 > exist yet, so the initial `0.1.0` is published manually with a token. Every
 > release after that uses the workflow above.
 
-### Submit to the n8n community nodes registry
+### Discovery on n8n
 
-1. Fork [`n8n-io/n8n-docs`](https://github.com/n8n-io/n8n-docs)
-2. Add an entry in `docs/integrations/community-nodes/installation/`
-3. Open a pull request referencing the npm package
+n8n has no per-node registry in its docs — community nodes are discovered as npm
+packages. Once published, anyone can install this node via **Settings → Community
+Nodes** (or `npm install`) by package name.
+
+For in-editor discovery (the "More from the community" panel), submit the package
+for verification at the [n8n Creator Portal](https://creators.n8n.io/nodes).
+Verification has its own requirements (package-name prefix, the
+`n8n-community-node-package` keyword, npm provenance, and constraints on runtime
+dependencies and license) — review them before submitting; an AWS-SDK-backed,
+Apache-2.0 package may need clarification with n8n on those constraints.
 
 ### Announce
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/n8n-nodes-agentcore",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/n8n-nodes-agentcore",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-agentcore": "^3.1075.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/n8n-nodes-agentcore",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "n8n community node for Amazon Bedrock AgentCore harness. Run production-grade AI agents with isolated microVMs, real browsers, real code execution, and persistent memory — directly from your n8n workflows.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Description

Release-prep for **v0.2.0** publish to public npm.

The Release workflow always **bumps** the version (`npm version <type>`), so to
publish exactly `0.2.0` via trusted publishing, `main` must sit at `0.1.1` and
the workflow is then run with a **minor** bump (`0.1.1 → 0.2.0`). This PR:

- Sets `package.json` / lock version `0.2.0 → 0.1.1` (the pre-bump base).
- Stamps the `CHANGELOG.md` `[0.2.0]` date.
- Replaces the inaccurate "Submit to the n8n community nodes registry" README
  section. n8n-docs has **no per-node registry** and rejects vendor listings as
  promotional; the real discovery path is npm install + the
  [n8n Creator Portal](https://creators.n8n.io/nodes) for in-editor verification.
  Notes that the AWS-SDK / Apache-2.0 constraints may need clarification with n8n.

No code changes — node behavior is unchanged from #19.

## Release steps (after this merges)

1. Actions → **Release** → Run workflow → bump type = **minor** → produces `0.2.0`.
2. Review + merge the auto-opened `release/v0.2.0` PR.
3. Approve the `npm-publish` GitHub Environment → trusted-publishing OIDC publish.

## Type of change

- [x] CI / repo hygiene (release prep)
- [x] Documentation update

## Checklist

- [x] PR title follows Conventional Commits (`chore:`)
- [x] `build` / `lint` / `typecheck` / `format` / `audit` pass
- [x] CHANGELOG updated

---

By submitting this pull request, I confirm my contribution is made under the terms of the project's Apache-2.0 license.
