### PR TITLE
docs: clarify node installs on self-hosted n8n (Cloud needs verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,23 @@ a working agent reply in ~5 minutes (install → credential → one prompt → m
 
 ## Installation
 
-### Via n8n UI (recommended)
+This node installs on **self-hosted n8n**. n8n Cloud only allows *verified*
+community nodes in its nodes panel; verification for this node is in progress
+(see [Discovery on n8n](#discovery-on-n8n)). If you run n8n Cloud today, you'll
+need a self-hosted instance to use this node.
 
-1. Open n8n
-2. **Settings → Community Nodes → Install a community node**
-3. Enter `@aws/n8n-nodes-agentcore`
-4. Accept the warning, click **Install**
+> New to self-hosting? You can run n8n locally with a single command
+> (`npx n8n`), or with Docker, or on a cloud provider. See the
+> [n8n self-hosting guide](https://docs.n8n.io/hosting/) for all options.
 
-### Manually
+### Via the n8n editor (self-hosted)
+
+1. Open your self-hosted n8n instance.
+2. Go to **Settings → Community Nodes → Install**.
+3. Enter `@aws/n8n-nodes-agentcore`.
+4. Acknowledge the community-node prompt, then choose **Install**.
+
+### Via npm (self-hosted)
 
 ```bash
 cd ~/.n8n
@@ -391,16 +400,17 @@ The package name `@aws/n8n-nodes-agentcore` matches n8n’s required
 
 ### Discovery on n8n
 
-n8n has no per-node registry in its docs — community nodes are discovered as npm
-packages. Once published, anyone can install this node via **Settings → Community
-Nodes** (or `npm install`) by package name.
+n8n has no per-node registry in its docs. Community nodes are discovered as npm
+packages, and installed on **self-hosted** n8n via **Settings → Community Nodes**
+(or `npm install`) by package name.
 
-For in-editor discovery (the "More from the community" panel), submit the package
-for verification at the [n8n Creator Portal](https://creators.n8n.io/nodes).
-Verification has its own requirements (package-name prefix, the
-`n8n-community-node-package` keyword, npm provenance, and constraints on runtime
-dependencies and license) — review them before submitting; an AWS-SDK-backed,
-Apache-2.0 package may need clarification with n8n on those constraints.
+Appearing in the in-editor nodes panel, and installing on **n8n Cloud**, both
+require the node to be **verified** through the
+[n8n Creator Portal](https://creators.n8n.io/nodes). n8n's verification currently
+requires an MIT license and no runtime dependencies. This node is Apache-2.0 and
+depends on the AWS SDK, so verification is not yet complete; it's tracked
+separately. Until then, use the node on self-hosted n8n as described in
+[Installation](#installation).
 
 ### Announce
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,25 +1,31 @@
 # Quick Start — your first agent in ~5 minutes
 
-This walks you from a fresh install to a working AI agent reply. No
-infrastructure to set up — the node provisions the harness for you on the first
-run. For the full feature reference see the [README](../README.md).
+This walks you from a fresh install to a working AI agent reply. You don't write
+any agent or AWS infrastructure code: the node provisions the harness for you on
+the first run. You do need a self-hosted n8n instance to install the node (see
+the prerequisites). For the full feature reference see the [README](../README.md).
 
 ## Prerequisites (one-time)
 
-1. **An AWS account** with Amazon Bedrock + AgentCore access in a supported
+1. **A self-hosted n8n instance.** This node installs on self-hosted n8n. n8n
+   Cloud only allows verified community nodes, and verification for this node is
+   in progress. You can run n8n locally with `npx n8n`, with Docker, or on a
+   cloud provider. See the [n8n self-hosting guide](https://docs.n8n.io/hosting/).
+2. **An AWS account** with Amazon Bedrock + AgentCore access in a supported
    region: `us-east-1`, `us-west-2`, `ap-southeast-2`, or `eu-central-1`.
-2. **A Bedrock model enabled** — in the Bedrock console → **Model access**,
+3. **A Bedrock model enabled** — in the Bedrock console → **Model access**,
    enable an Anthropic Claude model (e.g. Claude Sonnet 4.6). *Skipping this is
    the #1 cause of "AccessDenied" on the first run.*
-3. **AWS credentials** (access key + secret) for an IAM principal with the
+4. **AWS credentials** (access key + secret) for an IAM principal with the
    harness caller permissions, and an **execution role ARN** the harness assumes.
    See [IAM setup](../README.md#iam-setup). Trust policy:
    [`docs/iam-trust-policy.json`](./iam-trust-policy.json).
 
-## Step 1 — Install the node
+## Step 1 — Install the node (self-hosted n8n)
 
-In n8n: **Settings → Community Nodes → Install**, enter
-`@aws/n8n-nodes-agentcore`, accept, and install. Restart n8n if prompted.
+In your self-hosted n8n instance: **Settings → Community Nodes → Install**, enter
+`@aws/n8n-nodes-agentcore`, acknowledge the community-node prompt, and install.
+Restart n8n if prompted.
 
 ## Step 2 — Add the credential
 


### PR DESCRIPTION
## Description

Corrects the install instructions to match reality. n8n Cloud only lists
**verified** community nodes in its nodes panel, and n8n verification currently
requires an **MIT license** and **no runtime dependencies** (confirmed via
`npx @n8n/scan-community-package`). This node is Apache-2.0 and depends on the
AWS SDK, so it is **not verified yet and cannot be installed on n8n Cloud today**.
It installs and runs on **self-hosted** n8n.

The previous docs implied anyone could one-click install via the n8n UI, which
fails on n8n Cloud. This PR:

- README **Installation**: reframes around self-hosted n8n (editor install +
  npm), links the n8n self-hosting guide, and notes Cloud requires verification.
- README **Discovery on n8n**: states that in-panel discovery and Cloud install
  require verification, and that verification (MIT + no-deps) is tracked
  separately given this node is Apache-2.0 + AWS-SDK-backed.
- **QuickStart**: adds a self-hosted-instance prerequisite and clarifies the
  install step.

No code changes.

> Note: the npm page README won't reflect these edits until the next release
> (npm shows the README from the published version). A patch release can refresh
> it when convenient.

## Type of change

- [x] Documentation update

## Testing

- [x] Anchors resolve (`#installation`, `#discovery-on-n8n`, `#iam-setup`)
- [x] No remaining "anyone can install via the UI" framing

## Checklist

- [x] PR title follows Conventional Commits (`docs:`)

---

By submitting this pull request, I confirm my contribution is made under the terms of the project's Apache-2.0 license.
