### PR TITLE
fix: address n8n verification feedback (codex, setTimeout)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,9 @@ These come directly from `docs/SPEC.md` §9 and are checked in
   Adding a new node or credential requires updating that field.
 - The icon (`agentcore.svg`) must be referenced as `file:agentcore.svg`
   in the node description; gulp copies it next to the compiled JS.
-- The codex metadata in `AgentCoreHarness.node.json` (and the in-class
-  `codex` field) controls how the node surfaces in the n8n node-palette
-  search and the AI/AWS category filters.
+- The codex metadata in `AgentCoreHarness.node.json` controls how the
+  node surfaces in the n8n node-palette search and the
+  Development/Utility category filters.
 - Use `INodeProperties` types from `n8n-workflow` for all field
   definitions. Avoid `as any` casts in field definitions - they break
   n8n's UI validation.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ npm link @aws/n8n-nodes-agentcore
 npx n8n start
 ```
 
-Open `http://localhost:5678`. The **Amazon Bedrock AgentCore** node should appear in the node palette under the AI / AWS categories.
+Open `http://localhost:5678`. The **Amazon Bedrock AgentCore** node should appear in the node palette under the Development / Utility categories.
 
 ### Step 5 — Configure credentials and run an example
 

--- a/nodes/AgentCoreHarness/AgentCoreHarness.node.json
+++ b/nodes/AgentCoreHarness/AgentCoreHarness.node.json
@@ -2,7 +2,8 @@
 	"node": "n8n-nodes-agentcore.agentCoreHarness",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
-	"categories": ["AI", "AWS"],
+	"categories": ["Development", "Utility"],
+	"alias": ["agent", "bedrock", "agentcore", "aws", "llm", "claude", "anthropic"],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/nodes/AgentCoreHarness/AgentCoreHarness.node.ts
+++ b/nodes/AgentCoreHarness/AgentCoreHarness.node.ts
@@ -94,17 +94,6 @@ export class AgentCoreHarness implements INodeType {
 		defaults: {
 			name: 'Amazon Bedrock AgentCore',
 		},
-		codex: {
-			categories: ['AI', 'AWS', 'Development'],
-			subcategories: {
-				AI: ['Agents'],
-				AWS: ['Bedrock'],
-			},
-			alias: ['agent', 'bedrock', 'agentcore', 'aws', 'llm', 'claude', 'anthropic'],
-			resources: {
-				primaryDocumentation: [{ url: 'https://github.com/aws/n8n-nodes-agentcore' }],
-			},
-		},
 		inputs: ['main'],
 		outputs: ['main'],
 		credentials: [

--- a/nodes/AgentCoreHarness/helpers/client.ts
+++ b/nodes/AgentCoreHarness/helpers/client.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { sleep } from 'n8n-workflow';
 
 /**
  * Resolves AWS credentials from the n8n credential object into the
@@ -88,7 +89,7 @@ export async function waitForHarnessReady(
 			};
 		}
 
-		await new Promise((resolve) => setTimeout(resolve, pollInterval));
+		await sleep(pollInterval);
 	}
 
 	throw new Error(`Harness ${harnessId} did not reach READY within ${timeoutMs}ms`);


### PR DESCRIPTION
## Summary

Addresses the three issues filed by the n8n team:

- **#28** — Codex categories updated to valid values (`Development`, `Utility`). Moved `alias` array to the `.node.json` for search discoverability.
- **#29** — Removed the inline `codex` block from the node class. Community nodes should use only the external `.node.json` codex file.
- **#30** — Replaced `setTimeout` with `sleep()` from `n8n-workflow` to avoid the restricted-global violation.

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] No runtime testing needed — metadata-only (#28, #29) and a 1:1 function swap (#30)

Closes #28, closes #29, closes #30