### PR TITLE
docs: link regions doc + align license/dependency refs with SDK-free rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,11 @@ authoritative for the conventions below.
 - It targets the **AgentCore harness** primitive (declarative spec),
   not AgentCore Runtime (the container-hosting primitive).
 - It is **not** a general-purpose Bedrock client. It only speaks the
-  Harness control plane (`@aws-sdk/client-bedrock-agentcore-control`)
-  and data plane (`@aws-sdk/client-bedrock-agentcore`).
-- It is **not** a wrapper around the AgentCore CLI. Harness-consumer
-  logic is implemented directly on the AWS SDK v3 clients.
+  Harness control plane (`bedrock-agentcore-control`) and data plane
+  (`bedrock-agentcore`), called directly over HTTPS.
+- It is **not** a wrapper around the AgentCore CLI, and (as of the SDK-free
+  rewrite) **not** built on the AWS SDK. Harness-consumer logic calls the
+  AgentCore REST APIs directly with `fetch` + an inline SigV4 signer.
 
 ## Repo layout
 
@@ -78,7 +79,7 @@ calling `CreateHarness`.
 ## Build, lint, type-check, test
 
 ```
-npm run build         # tsc + gulp icon copy -> dist/
+npm run build         # tsc + icon/codex copy -> dist/
 npm run dev           # tsc --watch
 npm run lint          # eslint with eslint-plugin-n8n-nodes-base
 npm run typecheck     # tsc --noEmit (strict mode)
@@ -101,25 +102,26 @@ community nodes ship with zero runtime dependencies.
 Local testing against a real n8n is done via `npm link` into
 `~/.n8n/custom/`. See `README.md` "Local development" for the full flow.
 
-## Runtime dependencies - keep this list short
+## Runtime dependencies - keep this list at ZERO
 
-Today the package has **two** production deps:
+The package ships with **zero** production dependencies. n8n's community-node
+verification (and n8n Cloud) forbid runtime dependencies, so AWS calls are made
+with the global `fetch`, an inline SigV4 signer (`helpers/sigv4.ts`, `node:crypto`
+only), and an inline event-stream decoder (`helpers/eventstream.ts`). The AWS SDK
+was removed for exactly this reason.
 
-- `@aws-sdk/client-bedrock-agentcore`
-- `@aws-sdk/client-bedrock-agentcore-control`
+**Do not add a runtime dependency.** Any entry in `package.json` `dependencies`
+breaks verification and will fail n8n's scanner (`@n8n/scan-community-package`).
+If you think you need one:
 
-Both are Apache-2.0 and AWS-maintained. **Adding a runtime dependency is
-a security-review event** - it ships into every n8n install that adopts
-this node. Before adding one, confirm:
+- First try a small inline helper (the SigV4 signer and event-stream decoder are
+  the precedent — both were reimplemented inline rather than pulled in).
+- If it is genuinely unavoidable, it is a scope/verification decision, not a
+  routine change - discuss before adding.
 
-- License is permissive (Apache-2.0, MIT, BSD, ISC). The
-  `dependency-review` workflow enforces this.
-- It is actively maintained.
-- It does not pull in transitive deps with `exec`, `eval`, or native
-  bindings unless absolutely necessary.
-- It cannot be replaced by a small inline helper.
-
-`n8n-workflow` is a peer dep, supplied by n8n at runtime. Never bundle it.
+`n8n-workflow` is a peer dep, supplied by n8n at runtime. Never bundle it. The
+AWS SDK and `@smithy/*` are retained only as **devDependencies** for the offline
+signer-parity tests; they must never move to `dependencies`.
 
 ## Security invariants (enforced in CI)
 
@@ -133,8 +135,9 @@ These come directly from `docs/SPEC.md` §9 and are checked in
 - Credentials are read from the n8n credential vault per execution via
   `getCredentials('agentCoreApi')`. They are never persisted by the
   node and never logged.
-- TLS 1.2+ and SigV4 signing are inherited from `@aws-sdk` defaults;
-  do not override them.
+- TLS 1.2+ comes from Node's `fetch` default (all endpoints are hardcoded
+  `https://`, cert validation is never disabled). SigV4 signing is done inline
+  in `helpers/sigv4.ts` using `node:crypto`; do not weaken either.
 - TypeScript strict mode is non-negotiable (see `tsconfig.json`).
 
 ## n8n conventions specific to this repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ a public issue.
 ### Developer Certificate of Origin (DCO)
 
 By contributing, you certify that you wrote the code or have the right to
-contribute it under this project's license (Apache-2.0). All commits must
+contribute it under this project's license (MIT). All commits must
 include a sign-off line:
 
 ```
@@ -133,4 +133,4 @@ By participating, you agree to uphold this code.
 ## License
 
 By contributing, you agree that your contributions will be licensed under the
-project's [Apache-2.0 license](./LICENSE)
+project's [MIT license](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 An n8n community node for **Amazon Bedrock AgentCore harness**. Run production-grade AI agents with isolated microVMs, real browsers, real code execution, and persistent memory — directly from your n8n workflows.
 
-> Supported in the AgentCore regions us-east-1, us-west-2, ap-southeast-2, and
-> eu-central-1. Pin this package to a specific version in production and review
-> release notes before upgrading.
+> Available in the AWS Regions listed in the
+> [AgentCore Regions documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html).
+> Pin this package to a specific version in production and review release notes
+> before upgrading.
 
 ## Why this node?
 
@@ -68,7 +69,7 @@ npm install @aws/n8n-nodes-agentcore
 
 You need:
 
-1. **An AWS account** with Amazon Bedrock and AgentCore access in a supported region (us-east-1, us-west-2, ap-southeast-2, eu-central-1)
+1. **An AWS account** with Amazon Bedrock and AgentCore access in a supported region (see the [AgentCore Regions documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html))
 2. **AWS credentials** (access key + secret key) with the IAM policy below attached
 3. **An IAM execution role** that the harness assumes when running, with a trust policy and permissions described below
 4. **An enabled foundation model** in the Amazon Bedrock console (Claude Haiku, Sonnet, etc.)

--- a/README.md
+++ b/README.md
@@ -409,10 +409,10 @@ packages, and installed on **self-hosted** n8n via **Settings → Community Node
 
 Appearing in the in-editor nodes panel, and installing on **n8n Cloud**, both
 require the node to be **verified** through the
-[n8n Creator Portal](https://creators.n8n.io/nodes). n8n's verification currently
-requires an MIT license and no runtime dependencies. This node is Apache-2.0 and
-depends on the AWS SDK, so verification is not yet complete; it's tracked
-separately. Until then, use the node on self-hosted n8n as described in
+[n8n Creator Portal](https://creators.n8n.io/nodes). n8n's verification requires
+an MIT license and no runtime dependencies; this node is MIT-licensed and ships
+with zero runtime dependencies, and has been submitted for verification. Until
+verification is granted, use the node on self-hosted n8n as described in
 [Installation](#installation).
 
 ### Announce
@@ -479,4 +479,4 @@ endorsement.
 
 ## License
 
-Apache-2.0
+MIT


### PR DESCRIPTION
## Summary

Two docs-only changes, no code:

1. **Regions link** (original): the README hardcoded the AgentCore region list in two places, which goes stale. Both now point at the canonical [AgentCore Regions documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html).

2. **Align docs with the SDK-free rewrite (#40):** after #40 removed the AWS SDK and relicensed the package to MIT, several docs still described the old Apache-2.0 / SDK-dependent state. This corrects the factual staleness:
   - **README:** Discovery section no longer says the node is Apache-2.0 or depends on the AWS SDK; it now states the node meets n8n's verification requirements (MIT, zero runtime deps) and has been submitted. License section set to MIT.
   - **CONTRIBUTING:** DCO and License sections reference MIT.
   - **AGENTS:** runtime-dependencies section rewritten from "two production deps" to zero-deps; build command, transport description, and TLS/SigV4 note updated for `fetch` + the inline signer.

## Deliberately NOT changed

The **verification-status wording** in the Installation section ("self-hosted only / until verification is granted") is left as-is. That flips to "verified / available on n8n Cloud" in a separate pass once n8n actually grants verification, to avoid editing it twice.

## Note

Rebased onto current `main` (post-#40) so it doesn't revert any of #40's changes.

Docs only — no code, no tests affected.
