### PR TITLE
chore: set author email to a reachable address for node verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/aws/n8n-nodes-agentcore",
   "author": {
     "name": "Amazon Web Services",
-    "email": "open-source@amazon.com"
+    "email": "sdraghav@amazon.com"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
n8n's Creator Portal sends the node ownership-verification token to the `author.email` in package.json. It was set to `open-source@amazon.com`, which the maintainer submitting for verification can't currently receive. Point it at a reachable maintainer address so the token can be retrieved and verification can proceed.

Metadata only — no code change. Still satisfies the scanner's `valid-author` rule (non-empty name + email).

Follow-up: cut a 0.3.1 patch so the published package carries the updated email, then re-request the verification token.