### PR TITLE
fix: use full scoped package name as codex node prefix

### DIFF
--- a/nodes/AgentCoreHarness/AgentCoreHarness.node.json
+++ b/nodes/AgentCoreHarness/AgentCoreHarness.node.json
@@ -1,5 +1,5 @@
 {
-	"node": "n8n-nodes-agentcore.agentCoreHarness",
+	"node": "@aws/n8n-nodes-agentcore.agentCoreHarness",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Development", "Utility"],


### PR DESCRIPTION
## Why

n8n verification's manual review flagged one required change:

> **[MEDIUM] Codex `node` package prefix does not match npm name** — the `node` field must match the full npm package name.

The package is scoped (`@aws/n8n-nodes-agentcore`), so the codex `node` field needed the scope.

## Change

`nodes/AgentCoreHarness/AgentCoreHarness.node.json`:
- `node`: `n8n-nodes-agentcore.agentCoreHarness` → `@aws/n8n-nodes-agentcore.agentCoreHarness`

Metadata only — no code change. The node class `name` (`agentCoreHarness`) is unchanged. Build and lint pass. Targeting a 0.3.4 patch so we can resubmit for re-review.

Ref: [Node codex files](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-codex-files/)