### PR TITLE
fix: set codex nodeVersion back to 1.0

### DIFF
--- a/nodes/AgentCoreHarness/AgentCoreHarness.node.json
+++ b/nodes/AgentCoreHarness/AgentCoreHarness.node.json
@@ -1,6 +1,6 @@
 {
 	"node": "@aws/n8n-nodes-agentcore.agentCoreHarness",
-	"nodeVersion": "2.0",
+	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Development", "Utility"],
 	"alias": ["agent", "bedrock", "agentcore", "aws", "llm", "claude", "anthropic"],


### PR DESCRIPTION
## What

Reverts the codex `nodeVersion` field in `nodes/AgentCoreHarness/AgentCoreHarness.node.json` from `"2.0"` back to `"1.0"`.

## Why

Per n8n's [node codex reference](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-codex-files/), the codex `nodeVersion` field is part of the codex schema and should always be `"1.0"`. It is unrelated to the node's runtime `version` property (correctly `2` in the TypeScript class). It was mistakenly bumped alongside the runtime version in the 0.4.0 docs sync.

Addresses the last verification review item from n8n (LOW / housekeeping).