### PR TITLE
fix: sticky-note layout in all templates, and add a layout checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`examples/templates/build-a-multi-agent-support-team-with-shared-customer-memory.json`**
+  — a triage agent routes each question to one of three specialists. All four run
+  on one harness with tools granted per invocation, and share one memory per
+  customer scoped by Actor ID.
+- **`scripts/check-sticky-fit.mjs`** — checks sticky notes against how current n8n
+  renders them: content that clips, nodes covering sticky text, node name labels
+  spilling outside their group, sticky overlaps, and unused empty space.
+
+### Fixed
+
+- **Sticky-note layout in every template.** Node name labels render wider than the
+  node icon, so nodes near a sticky edge pushed their labels outside the group, and
+  nodes placed too high covered the sticky's own text. n8n's template review
+  reported both. Every workflow is relaid out with the node row below each sticky's
+  measured text and margins wide enough for labels.
+
+### Added
+
 - **End-to-end templates** in `examples/templates/`: a chat assistant with
   per-customer long-term memory, a webhook-driven statistics workflow that
   computes in the code interpreter and independently verifies the result in n8n,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nodes placed too high covered the sticky's own text. n8n's template review
   reported both. Every workflow is relaid out with the node row below each sticky's
   measured text and margins wide enough for labels.
+- **The chat templates returned an empty reply.** At `typeVersion` 1.1 with
+  `public: false` the Chat Trigger has no `responseMode`, so it answered the browser
+  as soon as the message arrived and the agent's reply never reached the chat panel.
+  `add-long-term-memory-to-an-n8n-ai-agent` and
+  `remember-each-customer-across-chat-sessions` now use `typeVersion` 1.4 with
+  `responseMode: lastNode`, matching the multi-agent template.
 
 ### Added
 

--- a/examples/09-memory-isolation-test.json
+++ b/examples/09-memory-isolation-test.json
@@ -7,22 +7,22 @@
     {
       "parameters": {
         "content": "## Memory persistence & actor isolation test\n\nGo/no-go check for the two claims every memory-based template depends on.\n\n### How it works\nThree webhook paths hit ONE auto-provisioned harness with managed memory.\n\n1. `POST /memory-test-store`: actor A stores a codename.\n2. `POST /memory-test-recall` — actor A asks for it back, in a **separate execution**. Must return the codename.\n3. `POST /memory-test-isolate`: actor B asks the same question on the **same Session ID**. Must NOT return the codename.\n\nThe verdict node asserts each result and returns `pass: true|false`, so you never have to eyeball the prose.\n\n### Setup\n1. Add an **Amazon Bedrock AgentCore API** credential (AWS keys, region, execution role ARN).\n2. Select it on all three AgentCore nodes.\n3. Activate the workflow, then run the three curl commands in the grey sticky **in order**.\n\nStep 1 provisions the harness and takes ~30 seconds. Steps 2 and 3 return in a few seconds.\n\n### Why it matters\nRecall proves memory survives across executions. Isolation proves one actor's memory never reaches another. Both must pass before any template claims per-user memory.",
-        "height": 660,
-        "width": 460
+        "height": 880,
+        "width": 520
       },
       "id": "sticky-overview",
       "name": "Sticky Note",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -1180,
-        -40
+        -1300,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Run these in order\n\n```\ncurl -X POST \\\n  <base>/memory-test-store\n\ncurl -X POST \\\n  <base>/memory-test-recall\n\ncurl -X POST \\\n  <base>/memory-test-isolate\n```\n\nWait ~15s between calls. Copy `<base>` from a Webhook node's Production URL.",
-        "height": 220,
+        "height": 360,
         "width": 1000,
         "color": 7
       },
@@ -31,14 +31,14 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -120,
-        880
+        -100,
+        1600
       ]
     },
     {
       "parameters": {
         "content": "## 1. Store (actor A)\nWrites the codename into managed memory under `actor-a`.",
-        "height": 200,
+        "height": 320,
         "width": 1000,
         "color": 7
       },
@@ -47,14 +47,14 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -120,
-        -40
+        -100,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## 2. Recall (actor A, separate execution)\nSame Actor ID, same Session ID, brand new execution. Expects the codename back.",
-        "height": 200,
+        "height": 320,
         "width": 1000,
         "color": 7
       },
@@ -63,14 +63,14 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -120,
-        300
+        -100,
+        680
       ]
     },
     {
       "parameters": {
         "content": "## 3. Isolate (actor B, same session)\nOnly the Actor ID changes. A leak here means per-user memory is unsafe to ship.",
-        "height": 200,
+        "height": 320,
         "width": 1000,
         "color": 7
       },
@@ -79,8 +79,8 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -120,
-        640
+        -100,
+        1080
       ]
     },
     {
@@ -126,8 +126,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        140,
-        40
+        240,
+        400
       ]
     },
     {
@@ -141,8 +141,8 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [
-        -60,
-        40
+        0,
+        400
       ]
     },
     {
@@ -164,8 +164,8 @@
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
       "typeVersion": 2,
       "position": [
-        420,
-        40
+        480,
+        400
       ],
       "credentials": {
         "agentCoreApi": {
@@ -183,8 +183,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        700,
-        40
+        720,
+        400
       ]
     },
     {
@@ -198,8 +198,8 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [
-        -60,
-        380
+        0,
+        800
       ]
     },
     {
@@ -239,8 +239,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        140,
-        380
+        240,
+        800
       ]
     },
     {
@@ -262,8 +262,8 @@
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
       "typeVersion": 2,
       "position": [
-        420,
-        380
+        480,
+        800
       ],
       "credentials": {
         "agentCoreApi": {
@@ -281,8 +281,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        700,
-        380
+        720,
+        800
       ]
     },
     {
@@ -296,8 +296,8 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [
-        -60,
-        720
+        0,
+        1200
       ]
     },
     {
@@ -337,8 +337,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        140,
-        720
+        240,
+        1200
       ]
     },
     {
@@ -360,8 +360,8 @@
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
       "typeVersion": 2,
       "position": [
-        420,
-        720
+        480,
+        1200
       ],
       "credentials": {
         "agentCoreApi": {
@@ -379,8 +379,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        700,
-        720
+        720,
+        1200
       ]
     }
   ],

--- a/examples/templates/add-long-term-memory-to-an-n8n-ai-agent.json
+++ b/examples/templates/add-long-term-memory-to-an-n8n-ai-agent.json
@@ -69,12 +69,16 @@
     },
     {
       "parameters": {
-        "options": {}
+        "options": {
+          "responseMode": "lastNode"
+        },
+        "public": false,
+        "mode": "hostedChat"
       },
       "id": "chat-trigger",
       "name": "When chat message received",
       "type": "@n8n/n8n-nodes-langchain.chatTrigger",
-      "typeVersion": 1.1,
+      "typeVersion": 1.4,
       "position": [
         0,
         423

--- a/examples/templates/add-long-term-memory-to-an-n8n-ai-agent.json
+++ b/examples/templates/add-long-term-memory-to-an-n8n-ai-agent.json
@@ -7,23 +7,23 @@
     {
       "parameters": {
         "content": "## Keep your AI Agent, add memory that lasts\n\nn8n's AI Agent with Simple Memory forgets everything once the buffer rolls over. This template keeps the AI Agent exactly where it is and attaches Amazon Bedrock AgentCore as a **tool**, so the agent can store and retrieve facts about a person that survive across executions.\n\n### How it works\n1. **When chat message received** starts a run per message.\n2. **Set User Identity** resolves who is talking.\n3. **AI Agent** handles the conversation, with:\n   - **OpenAI Chat Model** for the reply,\n   - **Simple Memory** for the last few turns of this chat,\n   - **Long-Term Memory** (Amazon Bedrock AgentCore, used as a tool) for anything that must outlive the buffer.\n4. The system message tells the agent to call the tool when it learns a durable fact and when it needs history it cannot see.\n\nShort-term recall stays fast and local. Long-term recall is scoped per person by **Actor ID**, so one user's history never reaches another.\n\n### Setup\n1. Add an **Amazon Bedrock AgentCore API** credential and select it on **Long-Term Memory**.\n2. Add an **OpenAI** credential on the chat model, or swap in any other chat model.\n3. In **Set User Identity**, map `userId` to your real user identifier. It defaults to the chat session so the template runs as imported.\n\nThe first tool call takes ~30 seconds while the harness is created, then a few seconds.\n\n### Customization\nReplace the Chat Trigger with Slack and map `userId` to the Slack user ID. Tighten the system message if you want the agent to write to long-term memory less often.",
-        "height": 800,
-        "width": 480
+        "height": 1000,
+        "width": 520
       },
       "id": "sticky-overview",
       "name": "Sticky Note",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -660,
-        -200
+        -700,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Who is talking\nActor ID must be stable per person, or long-term memory has nothing to key on.",
-        "height": 300,
-        "width": 420,
+        "height": 344,
+        "width": 540,
         "color": 7
       },
       "id": "sticky-identity",
@@ -31,14 +31,14 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -140,
-        20
+        -100,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## The agent you already know\nUnchanged n8n AI Agent. Simple Memory still covers the current conversation.",
-        "height": 300,
+        "height": 344,
         "width": 300,
         "color": 7
       },
@@ -47,15 +47,15 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        300,
-        20
+        520,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Memory that outlives the buffer\nAgentCore attached as a tool. The agent decides when to write and when to read.",
-        "height": 280,
-        "width": 620,
+        "height": 344,
+        "width": 700,
         "color": 7
       },
       "id": "sticky-tools",
@@ -63,8 +63,8 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        180,
-        380
+        380,
+        640
       ]
     },
     {
@@ -76,8 +76,8 @@
       "type": "@n8n/n8n-nodes-langchain.chatTrigger",
       "typeVersion": 1.1,
       "position": [
-        -100,
-        140
+        0,
+        423
       ],
       "webhookId": "33333333-3333-4333-8333-333333333333"
     },
@@ -106,8 +106,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        140,
-        140
+        240,
+        423
       ]
     },
     {
@@ -123,8 +123,8 @@
       "type": "@n8n/n8n-nodes-langchain.agent",
       "typeVersion": 1.7,
       "position": [
-        400,
-        140
+        620,
+        764
       ]
     },
     {
@@ -136,8 +136,8 @@
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1,
       "position": [
-        260,
-        460
+        480,
+        764
       ],
       "credentials": {
         "openAiApi": {
@@ -156,8 +156,8 @@
       "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
       "typeVersion": 1.3,
       "position": [
-        440,
-        460
+        700,
+        764
       ]
     },
     {
@@ -186,8 +186,8 @@
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarnessTool",
       "typeVersion": 2,
       "position": [
-        640,
-        460
+        920,
+        764
       ],
       "credentials": {
         "agentCoreApi": {

--- a/examples/templates/build-a-multi-agent-support-team-with-shared-customer-memory.json
+++ b/examples/templates/build-a-multi-agent-support-team-with-shared-customer-memory.json
@@ -1,0 +1,556 @@
+{
+  "name": "Build a multi-agent support team with shared customer memory using Amazon Bedrock AgentCore",
+  "meta": {
+    "instanceId": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## A team of agents that remembers each customer\n\nAsk a question in the chat. A triage agent decides who should answer and routes to one of three specialists, whose answer goes to Slack.\n\nWatch the second question. Every agent runs on **one** AgentCore harness, and each call carries an **Actor ID** for the customer, so the specialist answering now uses what another learned earlier. The team builds one memory of that person. Change the Actor ID and you get a separate memory from the same agents.\n\n### How it works\n\n1. **When Chat Message Received** starts a run per message.\n2. **Set Customer Context** holds the Actor ID and the Slack channel.\n3. **Triage Agent** provisions the shared harness on first run and returns a category as JSON.\n4. **Route To Specialist** picks one specialist.\n5. Each specialist invokes the **same harness** by ARN, with different tools granted for that call.\n6. **Post Answer To Slack** sends the reply, tagged with which specialist answered.\n\n### Setup\n\n1. Add an **Amazon Bedrock AgentCore API** credential and select it on all four agent nodes.\n2. Add a **Slack** credential, set `slackChannel` in Set Customer Context, and invite the bot to that channel.\n3. Open the chat and ask a question.\n\nFirst run takes 2 to 3 minutes while the harness is created. Only Triage provisions, so there is one billed harness, not four.\n\n### Customization\n\nMemory is a harness setting, so it lives on Triage under Provisioning Options, not on the specialists. **Agent Name is the key to the whole team's memory**; change it and the team starts over. `customerId` comes from the chat session here. In production, set it from your own user, account, or ticket ID so memory follows the person.",
+        "width": 520,
+        "height": 1040
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -700,
+        80
+      ],
+      "id": "sticky-overview",
+      "name": "Sticky Note"
+    },
+    {
+      "parameters": {
+        "content": "## Who is asking\n\nThe chat session becomes the Actor ID, so each conversation is its own customer. In production, set `customerId` from your own user or ticket ID.",
+        "width": 540,
+        "height": 520,
+        "color": 7
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -100,
+        80
+      ],
+      "id": "sticky-identity",
+      "name": "Sticky Note1"
+    },
+    {
+      "parameters": {
+        "content": "## Triage, and the one harness\n\nBlank Harness ARN, so this node creates the shared harness and returns its ARN for the specialists. Its Agent Name is the memory key: change it and the team starts over.",
+        "width": 540,
+        "height": 520,
+        "color": 7
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        520,
+        80
+      ],
+      "id": "sticky-triage",
+      "name": "Sticky Note2"
+    },
+    {
+      "parameters": {
+        "content": "## Three specialists, one harness\n\nEach invokes the same harness by ARN with different tools granted for that call, and the same Actor ID, so they share what they learn about this customer.",
+        "width": 560,
+        "height": 880,
+        "color": 7
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1140,
+        80
+      ],
+      "id": "sticky-specialists",
+      "name": "Sticky Note3"
+    },
+    {
+      "parameters": {
+        "content": "## Send the answer\n\nThe reply goes to the Slack channel set in Set Customer Context, tagged with which specialist answered.",
+        "width": 540,
+        "height": 780,
+        "color": 7
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1760,
+        80
+      ],
+      "id": "sticky-reply",
+      "name": "Sticky Note4"
+    },
+    {
+      "parameters": {
+        "content": "## Try it\n\nAsk all three in one chat:\n\n1. `p99 was 120, 340, 95, 610, 210 ms, mean and standard deviation?`\n2. `given that, how should I structure a serverless pipeline?`\n3. `what could cause a latency regression overnight?`\n\nDifferent specialist each time, same memory.",
+        "width": 520,
+        "height": 400,
+        "color": 7
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -700,
+        1180
+      ],
+      "id": "sticky-tryit",
+      "name": "Sticky Note5"
+    },
+    {
+      "parameters": {
+        "public": false,
+        "mode": "hostedChat",
+        "options": {
+          "responseMode": "lastNode"
+        }
+      },
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.4,
+      "position": [
+        0,
+        340
+      ],
+      "id": "chat-trigger",
+      "name": "When Chat Message Received",
+      "webhookId": "44444444-4444-4444-8444-444444444444"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "ctx-1",
+              "name": "agentName",
+              "type": "string",
+              "value": "support_team"
+            },
+            {
+              "id": "ctx-2",
+              "name": "customerId",
+              "type": "string",
+              "value": "={{ $json.sessionId }}"
+            },
+            {
+              "id": "ctx-3",
+              "name": "question",
+              "type": "string",
+              "value": "={{ $json.chatInput }}"
+            },
+            {
+              "id": "ctx-4",
+              "name": "slackChannel",
+              "type": "string",
+              "value": "#support"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.5,
+      "position": [
+        240,
+        340
+      ],
+      "id": "set-context",
+      "name": "Set Customer Context"
+    },
+    {
+      "parameters": {
+        "agentName": "={{ $json.agentName }}",
+        "modelProvider": "bedrock",
+        "modelId": "global.anthropic.claude-opus-4-8",
+        "systemPrompt": "You are the triage agent for a customer support team. Classify the customer's message into exactly one category:\n\n- \"analysis\" when the message contains numbers the customer wants computed or compared.\n- \"advice\" when the message asks for architecture, design, or best-practice guidance.\n- \"research\" for anything else, including troubleshooting and open questions.\n\nReply with a single JSON object and nothing else, using exactly these keys: category, summary. The summary is one short sentence restating what the customer wants.",
+        "prompt": "={{ $json.question }}",
+        "sessionId": "={{ 'cust-' + $json.customerId }}",
+        "additionalOptions": {
+          "actorId": "={{ $json.customerId }}",
+          "timeoutSeconds": 300
+        },
+        "provisioningOptions": {
+          "memoryMode": "managed",
+          "memoryStrategies": [
+            "SEMANTIC",
+            "SUMMARIZATION",
+            "USER_PREFERENCE"
+          ]
+        }
+      },
+      "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
+      "typeVersion": 2,
+      "position": [
+        620,
+        340
+      ],
+      "id": "triage",
+      "name": "Triage Agent",
+      "credentials": {
+        "agentCoreApi": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "Amazon Bedrock AgentCore API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// The triage agent is asked for bare JSON and reliably returns it, but a model\n// can still wrap output in a fence or add a sentence. Try every shape, and fall\n// back to research rather than dropping a customer's question.\nconst raw = String($json.response ?? '').trim();\n\nfunction extractJson(text) {\n  const fenced = text.match(/```(?:json)?\\s*([\\s\\S]*?)```/);\n  const candidate = fenced ? fenced[1].trim() : text;\n  try {\n    return JSON.parse(candidate);\n  } catch {}\n  const start = candidate.indexOf('{');\n  const end = candidate.lastIndexOf('}');\n  if (start !== -1 && end > start) {\n    try {\n      return JSON.parse(candidate.slice(start, end + 1));\n    } catch {}\n  }\n  return null;\n}\n\nconst parsed = extractJson(raw) ?? {};\nconst allowed = ['analysis', 'advice', 'research'];\nconst category = allowed.includes(parsed.category) ? parsed.category : 'research';\nconst ctx = $('Set Customer Context').item.json;\n\nreturn [{\n  json: {\n    category,\n    routedByFallback: !allowed.includes(parsed.category),\n    summary: parsed.summary ?? ctx.question,\n    question: ctx.question,\n    customerId: ctx.customerId,\n    // Every specialist reuses this ARN, so only this run provisioned a harness.\n    harnessArn: $json.harnessArn,\n  },\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        860,
+        340
+      ],
+      "id": "parse-triage",
+      "name": "Read Triage Decision"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "r-analysis",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.category }}",
+                    "rightValue": "analysis"
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "analysis"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "r-advice",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.category }}",
+                    "rightValue": "advice"
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "advice"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "r-research",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.category }}",
+                    "rightValue": "research"
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "research"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.4,
+      "position": [
+        1240,
+        340
+      ],
+      "id": "route",
+      "name": "Route To Specialist"
+    },
+    {
+      "parameters": {
+        "harnessArn": "={{ $json.harnessArn }}",
+        "agentName": "support_team",
+        "systemPrompt": "You are the analysis specialist on a customer support team. Compute every number by writing and running Python in the code interpreter. Never estimate and never do mental arithmetic. Use what you remember about this customer where it is relevant. Answer in at most four short sentences, suitable for a Slack reply.",
+        "prompt": "={{ $json.question }}",
+        "addTools": true,
+        "tools": {
+          "tool": [
+            {
+              "name": "code_interpreter",
+              "type": "agentcore_code_interpreter"
+            }
+          ]
+        },
+        "sessionId": "={{ 'cust-' + $json.customerId }}",
+        "additionalOptions": {
+          "actorId": "={{ $json.customerId }}",
+          "timeoutSeconds": 300
+        }
+      },
+      "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
+      "typeVersion": 2,
+      "position": [
+        1480,
+        340
+      ],
+      "id": "spec-analysis",
+      "name": "Analysis Specialist",
+      "credentials": {
+        "agentCoreApi": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "Amazon Bedrock AgentCore API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "harnessArn": "={{ $json.harnessArn }}",
+        "agentName": "support_team",
+        "systemPrompt": "You are the architecture specialist on a customer support team. Use the loaded AWS skills for design and best-practice guidance, and use what you remember about this customer, including their scale and region, where it is relevant. Answer in at most four short sentences, suitable for a Slack reply.",
+        "prompt": "={{ $json.question }}",
+        "addSkills": true,
+        "skills": {
+          "skill": [
+            {
+              "source": "awsSkills",
+              "paths": "core-skills/*"
+            }
+          ]
+        },
+        "sessionId": "={{ 'cust-' + $json.customerId }}",
+        "additionalOptions": {
+          "actorId": "={{ $json.customerId }}",
+          "timeoutSeconds": 300
+        }
+      },
+      "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
+      "typeVersion": 2,
+      "position": [
+        1480,
+        540
+      ],
+      "id": "spec-advice",
+      "name": "Architecture Specialist",
+      "credentials": {
+        "agentCoreApi": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "Amazon Bedrock AgentCore API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "harnessArn": "={{ $json.harnessArn }}",
+        "agentName": "support_team",
+        "systemPrompt": "You are the research specialist on a customer support team. Investigate the question using the shell and file tools in your sandbox where that helps, and use what you remember about this customer. If you are not certain, say what you would check next rather than guessing. Answer in at most four short sentences, suitable for a Slack reply.",
+        "prompt": "={{ $json.question }}",
+        "sessionId": "={{ 'cust-' + $json.customerId }}",
+        "additionalOptions": {
+          "actorId": "={{ $json.customerId }}",
+          "timeoutSeconds": 300
+        }
+      },
+      "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
+      "typeVersion": 2,
+      "position": [
+        1480,
+        740
+      ],
+      "id": "spec-research",
+      "name": "Research Specialist",
+      "credentials": {
+        "agentCoreApi": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "Amazon Bedrock AgentCore API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// One specialist ran, so exactly one branch reaches here. Unwrap fenced output\n// and never post an empty message to Slack.\nconst raw = String($json.response ?? '').trim();\n\nlet text = raw;\nconst fenced = raw.match(/^```(?:json)?\\s*([\\s\\S]*?)```$/);\nif (fenced) text = fenced[1].trim();\n\nif (!text) {\n  text = 'The agent returned an empty response, which is usually a transient service error. Please ask again.';\n}\n\nconst ctx = $('Read Triage Decision').item.json;\n\nreturn [{\n  json: {\n    reply: text,\n    answeredBy: ctx.category,\n    customerId: ctx.customerId,\n    usedCodeInterpreter: Array.isArray($json.toolUses)\n      && $json.toolUses.some((t) => String(t?.name ?? '').includes('code_interpreter')),\n    latencyMs: $json.latencyMs ?? null,\n  },\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        540
+      ],
+      "id": "format-reply",
+      "name": "Format Reply"
+    },
+    {
+      "parameters": {
+        "select": "channel",
+        "channelId": {
+          "__rl": true,
+          "mode": "name",
+          "value": "={{ $('Set Customer Context').item.json.slackChannel }}"
+        },
+        "text": "=*Answered by the {{ $json.answeredBy }} specialist* (customer: {{ $json.customerId }})\n\n{{ $json.reply }}",
+        "otherOptions": {
+          "includeLinkToWorkflow": false
+        }
+      },
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.5,
+      "position": [
+        2100,
+        540
+      ],
+      "id": "reply",
+      "name": "Post Answer To Slack",
+      "credentials": {
+        "slackApi": {
+          "id": "REPLACE_WITH_YOUR_SLACK_CREDENTIAL_ID",
+          "name": "Slack account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Set Customer Context": {
+      "main": [
+        [
+          {
+            "node": "Triage Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Triage Agent": {
+      "main": [
+        [
+          {
+            "node": "Read Triage Decision",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Triage Decision": {
+      "main": [
+        [
+          {
+            "node": "Route To Specialist",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route To Specialist": {
+      "main": [
+        [
+          {
+            "node": "Analysis Specialist",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Architecture Specialist",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Research Specialist",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Analysis Specialist": {
+      "main": [
+        [
+          {
+            "node": "Format Reply",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Architecture Specialist": {
+      "main": [
+        [
+          {
+            "node": "Format Reply",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Research Specialist": {
+      "main": [
+        [
+          {
+            "node": "Format Reply",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Reply": {
+      "main": [
+        [
+          {
+            "node": "Post Answer To Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "When Chat Message Received": {
+      "main": [
+        [
+          {
+            "node": "Set Customer Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {}
+}

--- a/examples/templates/calculate-campaign-statistics-from-a-webhook.json
+++ b/examples/templates/calculate-campaign-statistics-from-a-webhook.json
@@ -7,14 +7,14 @@
     {
       "parameters": {
         "content": "## Statistics that are computed, not estimated\n\nPost a batch of numbers to a webhook and get back real statistics. The agent writes Python and runs it in an isolated microVM, so the arithmetic is executed rather than predicted by a language model. Then n8n checks the answer before anyone reads it.\n\n### How it works\n\n1. **When Campaign Data Received** accepts a `POST` with a `values` array and an optional `label`.\n2. **Set Channel Config** normalises the payload and holds the values you edit.\n3. **Campaign Analysis Agent** runs on Amazon Bedrock AgentCore with the **Code Interpreter** tool enabled, and returns strict JSON.\n4. **Parse and Verify Data** recomputes every reported figure in n8n and compares. Any mismatch, or a run where the code interpreter did not fire, sets `verified: false`.\n5. **Send Summary to Slack** posts the result with that verified label attached.\n\nThe tool output is exact, but prose a model writes around a tool is not. The verification step is how you tell the two apart.\n\n### Setup\n\n1. Add an **Amazon Bedrock AgentCore API** credential (AWS keys, region, execution role ARN) and select it on the agent node.\n2. Add a **Slack** credential and set `slackChannel`, or delete the Slack node to run with one credential.\n3. Activate, then post a batch using the note below.\n\nKeep **Add Tools** switched on. With the toggle off the tool is ignored and the agent answers from the model alone, which still looks plausible.\n\nThe first run takes 30 to 60 seconds while the agent is provisioned.\n\n### Customization\n\nEdit the prompt and key list for percentiles, correlations, or a regression; the tool is a Python environment, not a fixed formula. Swap the Webhook for a Schedule Trigger for a nightly report.",
-        "width": 480,
-        "height": 768
+        "width": 520,
+        "height": 1060
       },
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -704,
-        192
+        -700,
+        280
       ],
       "id": "37a741bd-520c-4b10-92a1-81b7daa27300",
       "name": "Sticky Note"
@@ -22,15 +22,15 @@
     {
       "parameters": {
         "content": "## Receive and configure\n\nThe webhook starts the workflow and the nearby Config node prepares the request by setting the agent name, Slack channel, label, and values.",
-        "width": 448,
-        "height": 336,
+        "width": 540,
+        "height": 480,
         "color": 7
       },
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -144,
-        224
+        -100,
+        820
       ],
       "id": "2a038202-ad29-4ba4-9ce8-73c80c273332",
       "name": "Sticky Note1"
@@ -38,15 +38,15 @@
     {
       "parameters": {
         "content": "## Run statistics agent\n\nSends the prepared data to Amazon Bedrock AgentCore, which writes and executes Python in an isolated microVM. Add Tools must stay on.",
-        "width": 240,
-        "height": 368,
+        "width": 300,
+        "height": 480,
         "color": 7
       },
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        336,
-        192
+        520,
+        820
       ],
       "id": "9074d66f-4002-4a7d-8048-e1b2be76f4c4",
       "name": "Sticky Note2"
@@ -54,15 +54,15 @@
     {
       "parameters": {
         "content": "## Verify and notify\n\nParses the agent response defensively, recomputes every figure to verify it, and posts the summary to Slack with a verified label.",
-        "width": 496,
-        "height": 320,
+        "width": 540,
+        "height": 480,
         "color": 7
       },
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        656,
-        240
+        900,
+        820
       ],
       "id": "87329cf9-6fed-43dc-afbf-c90426a85ce4",
       "name": "Sticky Note3"
@@ -70,15 +70,15 @@
     {
       "parameters": {
         "content": "## Try it\n\n```\ncurl -X POST <production-url> \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"label\":\"Q3 email\",\n       \"values\":[12,45,7,88,23,\n                 56,91,34,19,67]}'\n```\n\nFor that input the mean is 44.2 and the population standard deviation is 28.944084. Check the agent output against those to confirm the tool really ran.",
-        "width": 448,
-        "height": 304,
+        "width": 520,
+        "height": 360,
         "color": 7
       },
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -144,
-        620
+        -700,
+        1380
       ],
       "id": "b41c9d7e-3f52-4a18-9c6d-5e2a8f7b1d40",
       "name": "Sticky Note4"
@@ -88,8 +88,8 @@
       "name": "When Campaign Data Received",
       "type": "n8n-nodes-base.webhook",
       "position": [
-        -100,
-        400
+        0,
+        1010
       ],
       "webhookId": "22222222-2222-4222-8222-222222222222",
       "parameters": {
@@ -104,8 +104,8 @@
       "name": "Set Channel Config",
       "type": "n8n-nodes-base.set",
       "position": [
-        160,
-        400
+        240,
+        1010
       ],
       "parameters": {
         "options": {},
@@ -145,8 +145,8 @@
       "name": "Campaign Analysis Agent",
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
       "position": [
-        380,
-        400
+        620,
+        1010
       ],
       "parameters": {
         "tools": {
@@ -183,8 +183,8 @@
       "name": "Parse and Verify Data",
       "type": "n8n-nodes-base.code",
       "position": [
-        700,
-        400
+        1000,
+        1010
       ],
       "parameters": {
         "jsCode": "// 1. Parse the agent's JSON defensively - it may arrive fenced or with prose.\nconst raw = String($json.response ?? '').trim();\n\nfunction extractJson(text) {\n  const fenced = text.match(/```(?:json)?\\s*([\\s\\S]*?)```/);\n  const candidate = fenced ? fenced[1].trim() : text;\n  try {\n    return JSON.parse(candidate);\n  } catch {}\n  const start = candidate.indexOf('{');\n  const end = candidate.lastIndexOf('}');\n  if (start !== -1 && end > start) {\n    try {\n      return JSON.parse(candidate.slice(start, end + 1));\n    } catch {}\n  }\n  return null;\n}\n\nconst stats = extractJson(raw);\nconst values = ($('Set Channel Config').item.json.values || []).map(Number).filter((n) => Number.isFinite(n));\n\nif (!stats || values.length === 0) {\n  return [{\n    json: {\n      ok: false,\n      verified: false,\n      reason: !stats\n        ? 'Could not parse a JSON object from the agent response.'\n        : 'No numeric values were supplied in the webhook body.',\n      rawResponse: raw.slice(0, 600),\n    },\n  }];\n}\n\n// 2. Recompute every figure the workflow reports, and compare. The code\n//    interpreter is exact, but any prose the model writes around the tool output\n//    is not, so nothing is labelled verified unless it was checked here.\nconst sorted = [...values].sort((a, b) => a - b);\nconst mid = Math.floor(sorted.length / 2);\n\nconst local = {\n  count: values.length,\n  mean: values.reduce((a, b) => a + b, 0) / values.length,\n  median: sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2,\n  min: sorted[0],\n  max: sorted[sorted.length - 1],\n};\n// Population standard deviation, matching statistics.pstdev in the prompt.\nlocal.stdev = Math.sqrt(\n  values.reduce((acc, v) => acc + (v - local.mean) ** 2, 0) / values.length,\n);\n\nfunction matches(reported, computed) {\n  const r = Number(reported);\n  if (!Number.isFinite(r)) return false;\n  const tolerance = Math.max(1e-6, Math.abs(computed) * 1e-6);\n  return Math.abs(r - computed) <= tolerance;\n}\n\nconst fields = ['count', 'mean', 'median', 'stdev', 'min', 'max'];\nconst fieldChecks = {};\nconst mismatched = [];\nfor (const f of fields) {\n  const ok = matches(stats[f], local[f]);\n  fieldChecks[f] = ok;\n  if (!ok) mismatched.push(f);\n}\n\n// The code interpreter must have run. A figure produced without it was predicted\n// by the model, not computed, so it does not qualify as verified.\nconst codeInterpreterUsed = Array.isArray($json.toolUses)\n  && $json.toolUses.some((t) => String(t?.name ?? '').includes('code_interpreter'));\n\nconst verified = mismatched.length === 0 && codeInterpreterUsed;\n\nlet note;\nif (verified) {\n  note = 'Every reported figure matches an independent recomputation in n8n.';\n} else if (!codeInterpreterUsed) {\n  note = 'The code interpreter did not run, so these figures came from the model rather than from executed code. Check that Add Tools is enabled.';\n} else {\n  note = `Mismatch against the local recomputation for: ${mismatched.join(', ')}. Do not trust these figures.`;\n}\n\nreturn [{\n  json: {\n    ok: true,\n    verified,\n    codeInterpreterUsed,\n    label: stats.label ?? $('Set Channel Config').item.json.label,\n    count: stats.count ?? local.count,\n    mean: Number(stats.mean),\n    median: stats.median ?? null,\n    stdev: stats.stdev ?? null,\n    min: stats.min ?? null,\n    max: stats.max ?? null,\n    check: {\n      fields: fieldChecks,\n      mismatched,\n      recomputed: local,\n      note,\n    },\n    latencyMs: $json.latencyMs ?? null,\n  },\n}];"
@@ -196,8 +196,8 @@
       "name": "Send Summary to Slack",
       "type": "n8n-nodes-base.slack",
       "position": [
-        1000,
-        400
+        1240,
+        1010
       ],
       "parameters": {
         "text": "=*Campaign statistics: {{ $json.label }}*\n{{ $json.verified ? ':white_check_mark: verified' : ':warning: NOT verified - see check.note' }}\n\n• count: {{ $json.count }}\n• mean: {{ $json.mean }}\n• median: {{ $json.median }}\n• std dev: {{ $json.stdev }}\n• min / max: {{ $json.min }} / {{ $json.max }}\n\nComputed in a microVM via the code interpreter.",

--- a/examples/templates/remember-each-customer-across-chat-sessions.json
+++ b/examples/templates/remember-each-customer-across-chat-sessions.json
@@ -7,23 +7,23 @@
     {
       "parameters": {
         "content": "## Support assistant with per-customer memory\n\nA chat assistant that remembers each customer separately, across separate workflow executions, with no vector database and no second credential.\n\n### How it works\n1. **When chat message received** starts a run for every message. n8n keeps one `sessionId` per browser, so each message is its own execution.\n2. **Set Customer Identity** holds the two values you tune: the agent name and the customer identifier.\n3. **Answer With Customer Memory** calls Amazon Bedrock AgentCore. It auto-provisions a harness on first run and reuses it afterwards. Managed memory is scoped by **Actor ID**, so each customer gets an isolated long-term history, and **Session ID** keeps one conversation continuous.\n4. **Format Chat Reply** parses the response defensively and returns the text to the chat.\n\nBecause memory lives in AgentCore rather than in the workflow, what a customer told you last week is still there next week.\n\n### Setup\n1. Add an **Amazon Bedrock AgentCore API** credential: AWS access key, secret, region, and your execution role ARN.\n2. Select it on the **Answer With Customer Memory** node.\n3. In **Set Customer Identity**, set `customerId` to something that identifies the person. It defaults to the chat session so the template runs unmodified; in production map it to your real user ID.\n4. Open the chat and say \"My order number is 12345\". Start a new chat later and ask \"What is my order number?\"\n\nFirst run takes ~30 seconds while the harness is created. Later runs return in a few seconds.\n\n### Customization\nChange the system prompt to fit your product. Swap the Chat Trigger for a Webhook or Slack trigger and map `customerId` to that channel's user ID. Turn on **Add Tools** to give the agent a code interpreter or browser.",
-        "height": 820,
-        "width": 480
+        "height": 1080,
+        "width": 520
       },
       "id": "sticky-overview",
       "name": "Sticky Note",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -620,
-        -160
+        -700,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Chat in, identity resolved\nEvery message is a separate execution. Config decides **whose** memory to use.",
-        "height": 320,
-        "width": 480,
+        "height": 360,
+        "width": 540,
         "color": 7
       },
       "id": "sticky-input",
@@ -32,13 +32,13 @@
       "typeVersion": 1,
       "position": [
         -100,
-        40
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Agent with per-customer memory\nActor ID scopes long-term memory to one customer. Session ID keeps the conversation continuous.",
-        "height": 320,
+        "height": 360,
         "width": 300,
         "color": 7
       },
@@ -47,15 +47,15 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        400,
-        40
+        520,
+        280
       ]
     },
     {
       "parameters": {
         "content": "## Reply\nParses the response defensively so a formatting quirk never breaks the chat.",
-        "height": 320,
-        "width": 280,
+        "height": 360,
+        "width": 300,
         "color": 7
       },
       "id": "sticky-reply",
@@ -63,8 +63,8 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        720,
-        40
+        900,
+        280
       ]
     },
     {
@@ -76,8 +76,8 @@
       "type": "@n8n/n8n-nodes-langchain.chatTrigger",
       "typeVersion": 1.1,
       "position": [
-        -60,
-        160
+        0,
+        423
       ],
       "webhookId": "11111111-1111-4111-8111-111111111111"
     },
@@ -112,8 +112,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        180,
-        160
+        240,
+        423
       ]
     },
     {
@@ -140,8 +140,8 @@
       "type": "@aws/n8n-nodes-agentcore.agentCoreHarness",
       "typeVersion": 2,
       "position": [
-        460,
-        160
+        620,
+        475
       ],
       "credentials": {
         "agentCoreApi": {
@@ -159,8 +159,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        780,
-        160
+        1000,
+        423
       ]
     }
   ],

--- a/examples/templates/remember-each-customer-across-chat-sessions.json
+++ b/examples/templates/remember-each-customer-across-chat-sessions.json
@@ -69,12 +69,16 @@
     },
     {
       "parameters": {
-        "options": {}
+        "options": {
+          "responseMode": "lastNode"
+        },
+        "public": false,
+        "mode": "hostedChat"
       },
       "id": "chat-trigger",
       "name": "When chat message received",
       "type": "@n8n/n8n-nodes-langchain.chatTrigger",
-      "typeVersion": 1.1,
+      "typeVersion": 1.4,
       "position": [
         0,
         423

--- a/scripts/check-sticky-fit.mjs
+++ b/scripts/check-sticky-fit.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Check that every sticky note in a workflow is large enough for its rendered
+ * content on current n8n, and that nothing overlaps.
+ *
+ * n8n changed sticky spacing and margins, so a sticky sized in an older version
+ * clips its text in a newer one. The n8n template review rejects that. This
+ * models the renderer from the values in n8n-editor-ui 2.33.x:
+ *
+ *   .sticky-textarea  height: calc(100% - 1.5rem)   -> 24px reserved
+ *                     padding: 0.5rem sides/top     -> 8px
+ *   h1  36px   h2  24px   h3/h4  16px    line-height 1.35, margin-bottom 8px
+ *   p / li  14px (--font-size--sm)       line-height 1.35, margin-bottom 8px
+ *   ul/ol   padding-left 1rem
+ *   pre>code  padding 1rem, does not wrap (overflow-x auto)
+ *
+ * Usage:
+ *   node scripts/check-sticky-fit.mjs <workflow.json> [...]
+ *
+ * Exit 1 if any sticky clips or overlaps, or a node sits on sticky text.
+ */
+
+import { readFileSync } from 'node:fs';
+
+const RESERVED_V = 24 + 8; // calc(100% - 1.5rem) plus 8px top padding
+const PAD_H = 16; // 8px left + 8px right
+const MARGIN_BLOCK = 8; // --spacing--2xs after headings, paragraphs, lists
+const LIST_INDENT = 16; // ul/ol padding-left 1rem
+const CODE_PAD = 32; // pre>code padding 1rem top and bottom
+
+// Average glyph width as a fraction of font size for the UI sans stack.
+// 0.52 is a deliberately safe overestimate; real text averages ~0.48.
+const GLYPH = 0.52;
+
+function lineHeight(fontPx) {
+	return Math.ceil(fontPx * 1.35);
+}
+
+/** Height in px of one markdown block once rendered inside a sticky. */
+function blockHeight(line, usableWidth) {
+	const h1 = /^#\s/.test(line);
+	const h2 = /^##\s/.test(line);
+	const h34 = /^#{3,6}\s/.test(line);
+	const li = /^\s*([-*+]|\d+\.)\s/.test(line);
+
+	let font = 14; // paragraph default
+	if (h1) font = 36;
+	else if (h2) font = 24;
+	else if (h34) font = 16;
+
+	// Strip markdown that does not occupy width when rendered.
+	let text = line
+		.replace(/^#{1,6}\s*/, '')
+		.replace(/^\s*([-*+]|\d+\.)\s*/, '')
+		.replace(/\*\*(.+?)\*\*/g, '$1')
+		.replace(/\*(.+?)\*/g, '$1')
+		.replace(/`(.+?)`/g, '$1')
+		.replace(/\[(.+?)\]\((.+?)\)/g, '$1');
+
+	const width = li ? usableWidth - LIST_INDENT : usableWidth;
+	const cols = Math.max(1, Math.floor(width / (font * GLYPH)));
+	const rows = Math.max(1, Math.ceil(text.length / cols));
+	return rows * lineHeight(font) + MARGIN_BLOCK;
+}
+
+/** Total rendered height of a sticky's markdown at a given box width. */
+export function contentHeight(content, boxWidth) {
+	const usable = boxWidth - PAD_H;
+	const lines = content.split('\n');
+	let total = RESERVED_V;
+	let inFence = false;
+	let fenceLines = 0;
+
+	for (const raw of lines) {
+		const line = raw.replace(/\s+$/, '');
+		if (/^```/.test(line)) {
+			if (inFence) {
+				// close: code block does not wrap, height is line count
+				total += fenceLines * lineHeight(14) + CODE_PAD + MARGIN_BLOCK;
+				fenceLines = 0;
+			}
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) {
+			fenceLines += 1;
+			continue;
+		}
+		if (line === '') {
+			total += MARGIN_BLOCK;
+			continue;
+		}
+		total += blockHeight(line, usable);
+	}
+	if (inFence && fenceLines) total += fenceLines * lineHeight(14) + CODE_PAD;
+	return Math.ceil(total);
+}
+
+function rect(n) {
+	const [x, y] = n.position;
+	return { x, y, w: n.parameters.width, h: n.parameters.height, x2: x + n.parameters.width, y2: y + n.parameters.height };
+}
+
+function overlaps(a, b) {
+	return a.x < b.x2 && b.x < a.x2 && a.y < b.y2 && b.y < a.y2;
+}
+
+// Importable as a module (contentHeight above); the report below runs only when
+// this file is executed directly.
+const isMain = process.argv[1] && process.argv[1].endsWith('check-sticky-fit.mjs');
+let problems = 0;
+const files = isMain ? process.argv.slice(2) : [];
+if (isMain && !files.length) {
+	console.error('usage: node scripts/check-sticky-fit.mjs <workflow.json> [...]');
+	process.exit(2);
+}
+
+for (const file of files) {
+	console.log(`\n=== ${file.split('/').pop()}`);
+	const wf = JSON.parse(readFileSync(file, 'utf8'));
+	const stickies = wf.nodes.filter((n) => n.type === 'n8n-nodes-base.stickyNote');
+	const others = wf.nodes.filter((n) => n.type !== 'n8n-nodes-base.stickyNote');
+
+	// 1. Does the content fit?
+	for (const s of stickies) {
+		const need = contentHeight(s.parameters.content, s.parameters.width);
+		const have = s.parameters.height;
+		const head = s.parameters.content.split('\n')[0].slice(0, 38);
+		if (need > have) {
+			console.log(`  CLIPS     ${head}`);
+			console.log(`            w=${s.parameters.width} h=${have}, content needs ~${need}px (short by ${need - have}px)`);
+			problems++;
+		} else {
+			const slack = Math.round(((have - need) / have) * 100);
+			console.log(`  fits      ${head}  (h=${have}, needs ~${need}, ${slack}% slack)`);
+			if (slack < 8) {
+				console.log(`            NOTE: under 8% slack, a font change would clip this`);
+			}
+		}
+	}
+
+	// 2. Sticky-on-sticky overlap, ignoring a section sticky nested in nothing.
+	for (let i = 0; i < stickies.length; i++) {
+		for (let j = i + 1; j < stickies.length; j++) {
+			if (overlaps(rect(stickies[i]), rect(stickies[j]))) {
+				console.log(`  OVERLAP   "${stickies[i].name}" and "${stickies[j].name}" intersect`);
+				problems++;
+			}
+		}
+	}
+
+	// 3. Node geometry against sticky bounds. An n8n node is ~100x100, but its
+	//    NAME renders centred underneath and is wider than the icon, so a node
+	//    near a sticky edge pushes its label outside the box. That is what looks
+	//    broken on the canvas even when the icon is inside.
+	const NODE = 100;
+	const LABEL_PAD = 60; // label overhang each side of the 100px icon
+	// The text band is not a guess: it is however tall this sticky's own rendered
+	// content actually is. A node overlapping that band covers real text.
+
+	for (const n of others) {
+		const [nx, ny] = n.position;
+		const icon = { x: nx, y: ny, x2: nx + NODE, y2: ny + NODE };
+		// label box: centred under the icon, wider, plus ~34px of text height
+		const label = {
+			x: nx - LABEL_PAD,
+			y: ny + NODE,
+			x2: nx + NODE + LABEL_PAD,
+			y2: ny + NODE + 34,
+		};
+
+		// Which section sticky is this node meant to live in? The one whose box
+		// contains the icon centre.
+		const cx = nx + NODE / 2, cy = ny + NODE / 2;
+		const home = stickies
+			.filter((s) => s.parameters.color === 7)
+			.find((s) => {
+				const r = rect(s);
+				return r.x <= cx && cx <= r.x2 && r.y <= cy && cy <= r.y2;
+			});
+
+		if (!home) {
+			console.log(`  NO GROUP  node "${n.name}" is not inside any section sticky`);
+			problems++;
+			continue;
+		}
+
+		const r = rect(home);
+		const head = home.parameters.content.split('\n')[0].slice(0, 28);
+		// icon fully inside?
+		if (icon.x < r.x || icon.x2 > r.x2 || icon.y < r.y || icon.y2 > r.y2) {
+			console.log(`  SPILLS    node "${n.name}" icon crosses the edge of "${head}"`);
+			problems++;
+		}
+		// label fully inside?
+		else if (label.x < r.x || label.x2 > r.x2 || label.y2 > r.y2) {
+			console.log(`  LABEL OUT node "${n.name}" name renders outside "${head}"`);
+			problems++;
+		}
+		// node over this sticky's rendered text?
+		const textEnd = r.y + contentHeight(home.parameters.content, home.parameters.width);
+		if (overlaps(icon, { x: r.x, y: r.y, x2: r.x2, y2: textEnd })) {
+			console.log(`  ON TEXT   node "${n.name}" covers text of "${head}" (text runs to y=${textEnd}, node starts y=${ny})`);
+			problems++;
+		}
+		// does this node's label reach into a DIFFERENT sticky?
+		for (const other of stickies) {
+			if (other === home) continue;
+			if (overlaps(label, rect(other))) {
+				console.log(`  BLEEDS    node "${n.name}" label reaches into "${other.parameters.content.split('\n')[0].slice(0, 26)}"`);
+				problems++;
+			}
+		}
+	}
+
+	// 4. Wasted space: a sticky far taller than its content reads as unfinished.
+	for (const s of stickies) {
+		const need = contentHeight(s.parameters.content, s.parameters.width);
+		const slack = (s.parameters.height - need) / s.parameters.height;
+		if (slack > 0.35 && s.parameters.color !== 7) {
+			console.log(`  EMPTY     overview sticky is ${Math.round(slack * 100)}% empty space (h=${s.parameters.height}, needs ~${need})`);
+			problems++;
+		}
+	}
+}
+
+if (isMain) {
+	console.log(
+		problems === 0
+			? '\nRESULT: every sticky fits its content, no overlaps, no nodes over text.'
+			: `\nRESULT: ${problems} problem(s) to fix before submitting.`,
+	);
+	process.exit(problems === 0 ? 0 : 1);
+}


### PR DESCRIPTION
n8n's template review reported clipped sticky text and nodes sitting on sticky content. Two causes:

- A node's name label renders wider than its 100px icon, so nodes near a sticky edge pushed their labels outside the group.
- Nodes were placed above where the sticky's text actually ends, covering it.

Every template is relaid out: one node row below each sticky's measured text height, 240px column pitch, and sticky margins wide enough for labels. Overview stickies trimmed so they no longer show dead space.

`scripts/check-sticky-fit.mjs` models the sticky renderer from n8n-editor-ui 2.33.x and fails on clipping, nodes over text, label spill, overlaps, and excess empty space.

Also adds the multi-agent support team template.

Verified: all five workflows pass the layout check and the export scan, JSON valid, sticky word counts within the Creator hub guidelines.