### PR TITLE
docs: correct the comparison with n8n's built-in AI Agent node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@ Listed on n8n at
 
 ## Why this node?
 
-n8n’s native AI Agent node is great for simple agents, but hits walls fast: no cross-session memory, no real browser, no real code execution, and short execution timeouts. AgentCore harness solves all four. This node is the bridge.
+n8n’s AI Agent node covers a lot of ground, and for many workflows it is all you need. AgentCore harness is for the cases where you want the agent loop, its execution environment and its memory managed for you: memory that persists across executions without you running a store for it, code and browser tools that execute inside an isolated microVM in your own AWS account, and long-running sessions. This node is the bridge.
 
-|Capability    |Native n8n AI Agent|AgentCore Agent (this node)               |
-|--------------|-------------------|------------------------------------------|
-|Memory        |Per-execution only |Cross-session, semantic, summary, episodic|
-|Code execution|Sandboxed JS only  |Full microVM with Python/Node/etc.        |
-|Browser       |None               |Cloud browser with real navigation        |
-|Session length|Workflow timeout   |Up to 8 hours per session                 |
-|Isolation     |Shared process     |Firecracker microVM per session           |
+|Capability    |n8n AI Agent, built in                          |AgentCore Agent (this node)               |
+|--------------|------------------------------------------------|------------------------------------------|
+|Memory        |Simple Memory in process; Postgres, Redis and other stores available as sub-nodes you operate|Managed store provisioned for you, scoped per actor, with semantic, summary and user-preference strategies|
+|Code execution|Code node runs JS or Python in the n8n process  |Python, Node and shell inside an isolated microVM|
+|Browser       |Community nodes such as Puppeteer, self-operated |Managed cloud browser|
+|Session length|Bounded by your execution timeout               |Long-running sessions, up to 8 hours      |
+|Isolation     |Shared n8n process                              |Firecracker microVM per session           |
+
+The distinction is not what n8n can do, it is what you have to run and secure
+yourself to do it.
 
 ## Features
 


### PR DESCRIPTION
The **Why this node?** section claimed n8n has "no cross-session memory" and "no real code execution". Neither is accurate:

- n8n ships Postgres, Redis, MongoDB and other Chat Memory sub-nodes that persist across sessions and restarts. Only Simple Memory is in-process.
- The Code node runs JS and Python, and the AI Agent can call it as a tool.

Reported by n8n partner engineering while reviewing our Verified Node Spotlight article.

The real difference is isolation and who operates the infrastructure, not whether the capability exists. Each table row now states what n8n offers today alongside what the harness manages instead, and the intro no longer implies the platform is missing these features.