### PR TITLE
docs: correct three unverified capability claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **npm package description** now says the node is verified, and `verified` was
   added to `keywords`. npm always publishes `README.md` regardless of the `files`
   field, so this release is what surfaces the verified status on the npm page.
+- **Three capability claims corrected in the README comparison table and feature
+  list.** All three described behaviour the node does not have. (1) "Session length:
+  up to 8 hours" cited a limit that belongs to other resources: `maxLifetime` on
+  `LifecycleConfiguration` is the AgentCore *Runtime* instance lifetime, and the
+  28800-second ceiling on `SessionConfiguration.sessionTimeoutInSeconds` is for MCP
+  *Gateway* sessions. The only duration this node sends is the per-invocation
+  `timeoutSeconds` (default 600), so no user could reach eight hours through it.
+  (2) "Streaming responses" was listed as a shipped feature, but `consumeStream()`
+  accumulates the event stream and returns a completed result; the node never calls
+  n8n's `sendChunk`, so nothing streams to the UI. Renamed to "Structured
+  responses", which is what it delivers, and moved streaming to the `later` roadmap
+  row. (3) "Firecracker microVM per session" named a hypervisor that AWS public
+  documentation does not, so the table and `docs/SPEC.md` now say "isolated microVM"
+  as the AgentCore docs do. Follows the same class of error as the AI Agent
+  comparison corrected in the previous entry.
 
 ## [0.4.0] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ n8n’s AI Agent node covers a lot of ground, and for many workflows it is all y
 |Memory        |Simple Memory in process; Postgres, Redis and other stores available as sub-nodes you operate|Managed store provisioned for you, scoped per actor, with semantic, summary and user-preference strategies|
 |Code execution|Code node runs JS or Python in the n8n process  |Python, Node and shell inside an isolated microVM|
 |Browser       |Community nodes such as Puppeteer, self-operated |Managed cloud browser|
-|Session length|Bounded by your execution timeout               |Long-running sessions, up to 8 hours      |
-|Isolation     |Shared n8n process                              |Firecracker microVM per session           |
+|Session length|Bounded by your execution timeout               |Long-running sessions, with a per-invocation timeout you set|
+|Isolation     |Shared n8n process                              |Isolated microVM per session              |
 
 The distinction is not what n8n can do, it is what you have to run and secure
 yourself to do it.
@@ -36,7 +36,7 @@ yourself to do it.
 - **VPC, custom containers, and filesystem mounts** (v0.2) — run in your VPC, bring a linux/arm64 ECR image, mount session storage / EFS / S3 Files
 - **OAuth Bearer invoke** (v0.2) — invoke inbound-OAuth harnesses with a JWT stored on the AgentCore API credential
 - **Versions & endpoints** (v0.2) — list immutable versions, pin named endpoints, invoke by qualifier
-- **Streaming responses** with structured tool-use trace, token usage, and latency metadata
+- **Structured responses** — tool-use trace, stop reason, token usage, and latency metadata on every invocation (the node consumes the AgentCore event stream and returns the completed result; it does not yet forward partial output to n8n's streaming UI)
 - **Session persistence** — pass the same session ID across executions for multi-turn conversations
 - **Execution limits** — max iterations, max tokens, timeout
 
@@ -472,10 +472,10 @@ zero runtime dependencies, and **is verified**. It is listed at
 
 |Version           |Capability                                                                                       |
 |------------------|-------------------------------------------------------------------------------------------------|
-|**v0.1**          |Run Agent, Invoke Existing, MCP / Browser / Code Interpreter / Gateway tools, streaming, sessions|
+|**v0.1**          |Run Agent, Invoke Existing, MCP / Browser / Code Interpreter / Gateway tools, sessions|
 |**v0.2**          |Multi-provider models, managed memory, VPC, custom containers, filesystem mounts, skills, inline functions, versions & endpoints|
 |**v0.4** (current)|OAuth Bearer Token moved to the credential, Add Tools / Add Skills toggles, AWS calls through n8n's HTTP helper, node `typeVersion` 2|
-|**later**         |ExecuteCommand (shell) with Bearer, custom Browser/Code Interpreter resources, CloudFormation quick-create, Export to Code, Step Functions|
+|**later**         |Streaming partial output to n8n's streaming UI, ExecuteCommand (shell) with Bearer, custom Browser/Code Interpreter resources, CloudFormation quick-create, Export to Code, Step Functions|
 
 ## Limitations (v0.2)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -14,7 +14,7 @@
 
 `@aws/n8n-nodes-agentcore` is an n8n community node that integrates Amazon Bedrock AgentCore harness into n8n workflows. It lets workflow developers run production-grade AI agents — with cross-session memory, real cloud browser, real microVM code execution, multi-provider model choice, skills, and long-running sessions — without writing infrastructure code or agent code.
 
-The node auto-provisions a harness on first execution, reuses it on subsequent runs, and updates it when configuration drifts. AWS credentials are read from n8n’s encrypted credential vault per execution, never persisted. All risky execution (model inference, browser, code interpreter) happens inside AWS-managed Firecracker microVMs, not inside the n8n process.
+The node auto-provisions a harness on first execution, reuses it on subsequent runs, and updates it when configuration drifts. AWS credentials are read from n8n’s encrypted credential vault per execution, never persisted. All risky execution (model inference, browser, code interpreter) happens inside AWS-managed isolated microVMs, not inside the n8n process.
 
 ## 2. Goals and non-goals
 
@@ -86,7 +86,7 @@ Three audiences, in priority order:
 │  │ - ListHarnesses      │                   ▼                   │
 │  │ - DeleteHarness      │     ┌─────────────────────────────┐   │
 │  └──────────┬───────────┘     │  Harness microVM            │   │
-│             │                 │  (Firecracker, isolated)    │   │
+│             │                 │  (isolated per session)     │   │
 │             │ assumes         │                             │   │
 │             ▼                 │  - Bedrock model inference  │   │
 │  ┌──────────────────────┐     │  - Browser tool             │   │


### PR DESCRIPTION
Docs only. Three claims in the README described behaviour the node does not have. Found while doing a pre-release check of the docs going out with the launch, and they are the same class of error as the AI Agent comparison corrected in #77.

### 1. "Session length: up to 8 hours"

The 28800-second figure appears twice in the SDK types, and neither is a harness session:

- `LifecycleConfiguration.maxLifetime` — default 28800s, but that is the **AgentCore Runtime** instance lifetime, not a harness session
- `SessionConfiguration.sessionTimeoutInSeconds` — max 28800s, but that is **MCP Gateway** session config

The node never sends either field (`grep -rn "maxLifetime\|idleRuntimeSessionTimeout" nodes/ credentials/` returns nothing). The only duration it sends is the per-invocation `timeoutSeconds`, default 600, described in the UI as "wall-clock timeout for the entire invocation". So no user could reach eight hours through this node.

Now reads: `Long-running sessions, with a per-invocation timeout you set`

### 2. "Streaming responses" listed as a shipped feature

`consumeStream()` reads the event stream and accumulates — the doc comment at the top of `helpers/stream.ts` says so. `grep -rn "sendChunk\|isStreaming" nodes/` returns nothing, so nothing reaches n8n's streaming UI. The node consumes a streaming API; it does not stream.

This matters because an n8n user reading the feature list would reasonably expect token-by-token output in the chat panel. An FSI SA asked about exactly this and offered to file a feature request.

Renamed to **Structured responses**, with the distinction stated explicitly, and streaming moved from the v0.1 roadmap row to `later`.

### 3. "Firecracker microVM per session"

AWS public documentation for AgentCore says "isolated microVM" and "session isolation" without naming the hypervisor. The only source for Firecracker in this repo is our own `docs/SPEC.md`, so the claim was circular. The comparison table and `docs/SPEC.md` (prose plus the ASCII diagram) now say "isolated microVM", matching the AgentCore docs.

### Why now

npm currently serves the pre-#77 README, so the next release is what puts the corrected text on the npm page. That release lines up with the n8n partner blog and the AWS channel post, so this is the last chance to get the docs right before traffic arrives.

### Checks run locally

`typecheck`, `lint`, `format:check`, `test` (114 passing / 12 files), `secrets:check` — all pass. No code touched, so no behaviour change and no node `typeVersion` bump.
